### PR TITLE
make open21xx buildable on current Linux distributions

### DIFF
--- a/as21/Makefile
+++ b/as21/Makefile
@@ -19,7 +19,7 @@
 #  along with the Open21xx toolkit; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-CFLAGS=-Wall -I../libas21 -I..
+CFLAGS=-m32 -O2 -Wall -I../libas21 -I..
 YFLAGS=-d
 
 # "make DEBUG=1" to turn debugging on in the compiler
@@ -60,16 +60,16 @@ OBJS_9X=$(CFILES_9X:.c=.o) $(GRAMMARS_9X:.y=.o) $(LEXERS:.l=.o)
 all: as218x as219x
 
 as218x: $(OBJS_8X) ../libas21/libas21.a
-	$(CC) -o $@ $^ -L ../libas21 -las21 -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -L ../libas21 -las21 -lelf
 
 as219x: $(OBJS_9X) ../libas21/libas21.a
-	$(CC) -o $@ $^ -L ../libas21 -las21 -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -L ../libas21 -las21 -lelf
 
 keytest8x: keytest.o keyword.o keytable8x.o
-	$(CC) -o $@ $(CFLAGS) $^
+	$(CC) $(CFLAGS) -o $@ $^
 
 keytest9x: keytest.o keyword.o keytable9x.o
-	$(CC) -o $@ $(CFLAGS) $^
+	$(CC) $(CFLAGS) -o $@ $^
 
 as21.o: as21.c as21-lex.h listing.h symbol.h grammar.h \
 	../defs.h ../adielf.h

--- a/elfdump/Makefile
+++ b/elfdump/Makefile
@@ -21,14 +21,14 @@
 #
 YFLAGS=-d -v
 
-CFLAGS= -I.. -g
+CFLAGS=-m32 -O2 -I.. -g
 
 TARGET=elfdump
 
 .PHONY: clean
 
 $(TARGET): $(TARGET).o
-	$(CC) -o $(TARGET) $^ -lelf
+	$(CC) $(CFLAGS) -o $(TARGET) $^ -lelf
 
 $(TARGET).c :
 

--- a/elfdump/elfdump.c
+++ b/elfdump/elfdump.c
@@ -21,6 +21,7 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include <fcntl.h>
 #include <elf.h>
 #include <libelf.h>

--- a/ez21/Makefile
+++ b/ez21/Makefile
@@ -19,7 +19,7 @@
 #  along with the Open21xx toolkit; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-CFLAGS= -g -I ..
+CFLAGS=-m32 -O2 -g -I ..
 
 # "make NDEBUG=1" to compile out asserts
 ifdef NDEBUG
@@ -31,7 +31,7 @@ TARGET=ez21
 .PHONY: clean
 
 $(TARGET): $(TARGET).o
-	$(CC) -o $@ $^ -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -lelf
 
 ez21.o: ez21.c ../defs.h ../adielf.h
 

--- a/ez21/ez21.c
+++ b/ez21/ez21.c
@@ -145,12 +145,12 @@ static Elf32_Half download_machine( const char *filename )
     return machine;
 }
 
-inline unsigned long data_word( unsigned char *data )
+unsigned long data_word( unsigned char *data )
 {
     return ((unsigned long)*data << 8) | ((unsigned long)*(data+1));
 }
 
-inline unsigned long program_word( unsigned char *data )
+unsigned long program_word( unsigned char *data )
 {
     return ((unsigned long)*data << 16) |
         ((unsigned long)*(data+1) << 8) |

--- a/ez21/ez21.c
+++ b/ez21/ez21.c
@@ -223,7 +223,7 @@ int received( int expected )
     return i;
 }
 
-int write_drain( int fd, const unsigned char *data, unsigned long length )
+void write_drain( int fd, const unsigned char *data, unsigned long length )
 {
     int i, result, block;
 

--- a/ld21/Makefile
+++ b/ld21/Makefile
@@ -19,7 +19,7 @@
 #  along with the Open21xx toolkit; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-CFLAGS=-Wall -I ../libas21
+CFLAGS=-m32 -O2 -Wall -I ../libas21
 YFLAGS=-d
 
 # "make DEBUG=1" to turn debugging on in the compiler
@@ -44,7 +44,7 @@ GRAMMARS=ld21-grammar.y
 ld21: ld21-grammar.o ld21-lex.o dspmem.o namelist.o macro.o \
 		 execfile.o array.o fixup.o \
 		../libas21/libas21.a
-	$(CC) -o $@ $^ -L ../libas21 -las21 -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -L ../libas21 -las21 -lelf
 
 ld21-grammar.c ld21-grammar.h: ld21-grammar.y ld21-lex.h dspmem.h \
 		namelist.h macro.h execfile.h \

--- a/libas21/Makefile
+++ b/libas21/Makefile
@@ -19,7 +19,7 @@
 #  along with the Open21xx toolkit; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-CFLAGS=-Wall -I..
+CFLAGS=-m32 -O2 -Wall -I..
 
 # "make DEBUG=1" to turn on compiler debugging
 ifdef DEBUG

--- a/verify21/Makefile
+++ b/verify21/Makefile
@@ -22,7 +22,7 @@
 YFLAGS+=-d -v
 LFLAGS+= -d -L
 
-CFLAGS= -g -DYYDEBUG
+CFLAGS=-m32 -O2 -g -DYYDEBUG
 
 TARGET=verify21
 
@@ -41,7 +41,7 @@ check9x: $(TARGET)
 	../as21/as219x -o preproc.o -dv -I incdir2 -I incdir -I include preproc.dsp | ./verify21
 
 $(TARGET): $(TARGET)-grammar.o $(TARGET)-lex.o
-	$(CC) -o $(TARGET) $^
+	$(CC) $(CFLAGS) -o $(TARGET) $^
 
 $(TARGET)-lex.o: $(TARGET)-lex.c verify21-grammar.h
 

--- a/verify21/verify21-grammar.y
+++ b/verify21/verify21-grammar.y
@@ -35,6 +35,9 @@ static int verify_length, verify_index;
 static int recovering;
 static char error_buf[128];
 
+int yylex();
+int yyerror(const char *);
+
 %}
 
 %union {


### PR DESCRIPTION
Just modified the makefiles and the sources to make it buildable on a current day Linux distributions including forcing 32 bit building, because the code does not seem to be 64 bit safe. Also fixed some smaller linking and other issues.